### PR TITLE
fix perfetto default empty tracker show up for each process group.

### DIFF
--- a/ui/src/controller/track_decider.ts
+++ b/ui/src/controller/track_decider.ts
@@ -1050,7 +1050,7 @@ class TrackDecider {
         from process_track
         left join process using(upid)
         where
-            process_track.name is null or
+            process_track.name is not null or
             process_track.name not like "% Timeline"
         group by
           process_track.upid,


### PR DESCRIPTION
the default tracker with the same name as the process group has null trackername if not specified, by quering with filter to exclude this tracker we can avoid it show up the perfetto UI.